### PR TITLE
IAS infobox standard, not deprecated

### DIFF
--- a/src/FLARM/Traffic.hpp
+++ b/src/FLARM/Traffic.hpp
@@ -181,7 +181,7 @@ struct FlarmTraffic {
    * @return true if the object is still valid
    */
   bool Refresh(fixed Time) {
-    valid.Expire(Time, fixed(5));
+    valid.Expire(Time, fixed(20));  //<<< was 5
     return valid;
   }
 

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -527,7 +527,7 @@ static constexpr MetaData meta_data[] = {
     IBFHelper<InfoBoxContentSpeedIndicated>::Create,
     e_Load_G, // G load
     e_Track_GPS, // Track
-    DEPRECATED,
+    STANDARD,
   },
 
   // e_H_Baro


### PR DESCRIPTION
Makes it easier to find this infobox when customizing screens.  When Tophat is running standalone, this infobox is important to look at and compare to the ASI, as a sanity check on Tophat's wind estimate.